### PR TITLE
fix WordNetAug.substitute, pos instead of tokens

### DIFF
--- a/nlpaug/augmenter/word/wordnet.py
+++ b/nlpaug/augmenter/word/wordnet.py
@@ -29,8 +29,8 @@ class WordNetAug(WordAugmenter):
         tokens = self.tokenizer(text)
 
         pos = nltk.pos_tag(tokens)
-
-        aug_idexes = self._get_aug_idxes(tokens)
+        # fix this fuction, pos instead of tokens
+        aug_idexes = self._get_aug_idxes(pos)
 
         for i, token in enumerate(tokens):
             # Skip if no augment for word

--- a/nlpaug/augmenter/word/wordnet.py
+++ b/nlpaug/augmenter/word/wordnet.py
@@ -57,6 +57,7 @@ class WordNetAug(WordAugmenter):
                 results.append(token)
             else:
                 candidate = self.sample(augmented_data, 1)[0]
+                candidate = candidate.replace("_", " ").replace("-", " ").lower()
                 results.append(self.align_capitalization(token, candidate))
 
         return self.reverse_tokenizer(results)


### PR DESCRIPTION
self.skip_aug requires a list of tuples.

```
def skip_aug(self, token_idxes, tokens):
        results = []
        for token_idx in token_idxes:
            # Some word does not come with synonym. It will be excluded in lucky draw.
            if tokens[token_idx][1] not in ['DT']:
                results.append(token_idx)

        return results

```