### PR TITLE
Fix Fairseq call to torch.hub. load()

### DIFF
--- a/nlpaug/model/lang_models/fairseq.py
+++ b/nlpaug/model/lang_models/fairseq.py
@@ -32,11 +32,11 @@ class Fairseq(LanguageModels):
         
         if is_load_from_github:
             self.from_model = torch.hub.load(
-                github='pytorch/fairseq', model=from_model_name,
+                repo_or_dir='pytorch/fairseq', model=from_model_name,
                 checkpoint_file=from_model_checkpt,
                 tokenizer=tokenzier_name, bpe=bpe_name)
             self.to_model = torch.hub.load(
-                github='pytorch/fairseq', model=to_model_name,
+                repo_or_dir='pytorch/fairseq', model=to_model_name,
                 checkpoint_file=to_model_checkpt,
                 tokenizer=tokenzier_name, bpe=bpe_name)
         else:


### PR DESCRIPTION
Thanks for the library!

I was following the doc example of [Backtranslation Augmenter](https://github.com/makcedward/nlpaug/blob/master/example/textual_augmenter.ipynb) and realized that on [class Fairseq](https://github.com/makcedward/nlpaug/blob/master/nlpaug/model/lang_models/fairseq.py#L34) `torch.hub.load` is called. [The API of this method changed](https://github.com/pytorch/pytorch/commit/1cab27d4851b13868fb68d2b6b33111a3c58a518#diff-29c81dcbb321a86cb0be86ba1bd93ae84b3233979763959f0f2f36d5e67b196cR314) on 21/09/2020, this PR updates the parameter name accordingly.