### PR TITLE
feat: do not spawn a thread for `num_thread=1`

### DIFF
--- a/nlpaug/base_augmenter.py
+++ b/nlpaug/base_augmenter.py
@@ -172,18 +172,24 @@ class Augmenter:
 
     @classmethod
     def _parallel_augment(cls, action_fx, data, n, num_thread=2):
-        pool = ThreadPool(num_thread)
-        results = pool.map(action_fx, [data] * n)
-        pool.close()
-        pool.join()
+        if num_thread == 1:
+            results = [action_fx(data) for _ in range(n)]
+        else:
+            pool = ThreadPool(num_thread)
+            results = pool.map(action_fx, [data] * n)
+            pool.close()
+            pool.join()
         return results
 
     @classmethod
     def _parallel_augments(cls, action_fx, data):
-        pool = ThreadPool(len(data))
-        results = pool.map(action_fx, data)
-        pool.close()
-        pool.join()
+        if len(data) == 1:
+            results = [action_fx(data)]
+        else:
+            pool = ThreadPool(len(data))
+            results = pool.map(action_fx, data)
+            pool.close()
+            pool.join()
         return results
 
     def insert(self, data):

--- a/nlpaug/base_augmenter.py
+++ b/nlpaug/base_augmenter.py
@@ -112,7 +112,13 @@ class Augmenter:
 
             # Single input with/without multiple input
             else:
-                augmented_results = self._parallel_augment(action_fx, clean_data, n=n, num_thread=num_thread)
+                # Single Thread
+                if num_thread == 1:
+                    augmented_results = [action_fx(clean_data) for _ in range(n)]
+
+                # Multi Thread
+                else:
+                    augmented_results = self._parallel_augment(action_fx, clean_data, n=n, num_thread=num_thread)
 
             if len(augmented_results) >= expected_output_num:
                 break
@@ -172,24 +178,18 @@ class Augmenter:
 
     @classmethod
     def _parallel_augment(cls, action_fx, data, n, num_thread=2):
-        if num_thread == 1:
-            results = [action_fx(data) for _ in range(n)]
-        else:
-            pool = ThreadPool(num_thread)
-            results = pool.map(action_fx, [data] * n)
-            pool.close()
-            pool.join()
+        pool = ThreadPool(num_thread)
+        results = pool.map(action_fx, [data] * n)
+        pool.close()
+        pool.join()
         return results
 
     @classmethod
     def _parallel_augments(cls, action_fx, data):
-        if len(data) == 1:
-            results = [action_fx(data)]
-        else:
-            pool = ThreadPool(len(data))
-            results = pool.map(action_fx, data)
-            pool.close()
-            pool.join()
+        pool = ThreadPool(len(data))
+        results = pool.map(action_fx, data)
+        pool.close()
+        pool.join()
         return results
 
     def insert(self, data):


### PR DESCRIPTION
The spawning of a single thread on my computer produces a huge time overhead.

Thus I propose to add an if clause that would lead to no multithreading when `num_thread=1` is used. This is already implemented for the case when multiple inputs are used, but isn't for the case when a single string is being input to `.augment()`.

I have benchmarked with the following code:
```python
import random
import time
import nlpaug.augmenter.char as nac

aug = nac.OcrAug()
times = []
for i in range(100):
    start = time.time()
    aug.augment(''.join(random.choice('qwertyuiopsdfghj klzxcv bnm,') for _ in range(random.randint(10, 30))))
    times.append(time.time() - start)
print(sum(times) / len(times))
```

For the `dev` version of `nlpaug` it results in the delta time of `0.10184303998947143`, while the proposed version results in `9.496212005615235e-05`, which makes huge difference.