### PR TITLE
Update from_model_name and to_model_name in Back Translation task

### DIFF
--- a/example/textual_augmenter.ipynb
+++ b/example/textual_augmenter.ipynb
@@ -927,8 +927,8 @@
     "\n",
     "text = 'The quick brown fox jumped over the lazy dog'\n",
     "back_translation_aug = naw.BackTranslationAug(\n",
-    "    from_model_name='transformer.wmt19.en-de', \n",
-    "    to_model_name='transformer.wmt19.de-en'\n",
+    "    from_model_name='facebook/wmt19-en-de', \n",
+    "    to_model_name='facebook/wmt19-de-en'\n",
     ")\n",
     "back_translation_aug.augment(text)"
    ]


### PR DESCRIPTION
Update `from_model_name` and `to_model_name` from transformer.wmt19.en-de and transformer.wmt19.de-en to facebook/wmt19-en-de and facebook/wmt19-de-en [hosted on Huggingface] respectively. It was breaking the code in the version 1.1.4.