### PR TITLE
Add `pandas` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.16.2
+pandas>=1.2.0
 requests>=2.22.0


### PR DESCRIPTION
Hi there! In your most recent release, it seems like you now import `pandas` in `base_augmenter.py` however `pandas` is not referenced in your `requirements.txt` leading to a `ModuleNotFoundError` (as seen [here](https://github.com/facebookresearch/AugLy/pull/84/checks?check_run_id=3088839972)). 

This PR addresses this issue :) I chose v1.2.0 as a base version and ensured that the functions you use exist there too. If you prefer to use a different base version, by all means! :)