### PR TITLE
Remove unused torch import

### DIFF
--- a/nlpaug/augmenter/word/back_translation.py
+++ b/nlpaug/augmenter/word/back_translation.py
@@ -4,7 +4,6 @@
 
 import string
 import os
-import torch
 
 from nlpaug.augmenter.word import WordAugmenter
 import nlpaug.model.lang_models as nml


### PR DESCRIPTION
In `nlpaug/augmenter/word/back_translation.py `, `torch` is imported but not used. This PR removes the `torch` import
@makcedward 