### PR TITLE
Allow aug_p=0

### DIFF
--- a/nlpaug/base_augmenter.py
+++ b/nlpaug/base_augmenter.py
@@ -241,7 +241,7 @@ class Augmenter:
         raise NotImplementedError
 
     def _generate_aug_cnt(self, size, aug_min, aug_max, aug_p=None):
-        if aug_p:
+        if aug_p is not None:
             percent = aug_p
         elif self.aug_p:
             percent = self.aug_p


### PR DESCRIPTION
Current behavior overwrites aug_p=0 (aug_p=Falsy) to aug_p=0.3
Suggested change only does this is aug_p is actually undefined