### PR TITLE
Typo in Word Embeddings Augmenter example

### DIFF
--- a/example/textual_language_augmenter.ipynb
+++ b/example/textual_language_augmenter.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "# https://github.com/taishi-i/nagisa\n",
     "import nagisa\n",
-    "def tokenizer(x):\n",
+    "def tokenizer(text):\n",
     "    return nagisa.tagging(text).words\n",
     "\n",
     "text = '速い茶色の狐が怠惰なな犬を飛び越えます'\n",


### PR DESCRIPTION
This pull request corrects a typo in Word Embeddings Augmenter (fasttext, Japanese) example.