### PR TITLE
SentenceAugmenter data cleaning type-checks to catch all list-comprehensible classes

### DIFF
--- a/nlpaug/augmenter/sentence/sentence_augmenter.py
+++ b/nlpaug/augmenter/sentence/sentence_augmenter.py
@@ -3,9 +3,10 @@ import re
 from nlpaug.util import Method
 from nlpaug.util.text.tokenizer import Tokenizer
 from nlpaug import Augmenter
+from typing import Iterable
 
 
-class SentenceAugmenter(Augmenter):    
+class SentenceAugmenter(Augmenter):
     def __init__(self, action, name='Sentence_Aug', stopwords=None, tokenizer=None, reverse_tokenizer=None,
                  device='cuda', aug_min=None, aug_max=None, aug_p=None, include_detail=False, verbose=0):
         super().__init__(
@@ -17,7 +18,7 @@ class SentenceAugmenter(Augmenter):
 
     @classmethod
     def clean(cls, data):
-        if isinstance(data, list) :
+        if isinstance(data, Iterable):
             return [d.strip() for d in data]
         return data.strip()
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -35,15 +35,15 @@ if __name__ == '__main__':
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.test_base_augmenter'))
     # suites.append(unittest.TestLoader().loadTestsFromName('util.text.test_tokenizer'))
     # suites.append(unittest.TestLoader().loadTestsFromName('util.selection.test_filtering'))
-    
+
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.test_text_augmenter'))
-    
+
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.sentence.test_sentence'))
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.sentence.test_context_word_embs_sentence'))
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.sentence.test_abst_summ'))
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.sentence.test_lambada'))
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.sentence.test_random'))
-    
+
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.word.test_word'))
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.word.test_tfidf'))
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.word.test_spelling'))
@@ -55,12 +55,12 @@ if __name__ == '__main__':
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.word.test_random_word'))
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.word.test_reserved'))
     # suites.append(unittest.TestLoader().loadTestsFromName('model.word.test_word_embs_model'))
-    
+
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.char.test_char'))
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.char.test_keyboard'))
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.char.test_ocr'))
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.char.test_random_char'))
-    
+
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.test_audio_augmenter'))
 
     # suites.append(unittest.TestLoader().loadTestsFromName('augmenter.audio.test_audio'))


### PR DESCRIPTION
I ran into an issue where I created a Flow of multiple augmenters, some of which expect np.arrays and others expect lists. The SentenceAugmenter class only works with types of string/list, so if I had both types of augmenters, augmenting with the Flow would eventually fail within SentenceAugmenter:

https://github.com/makcedward/nlpaug/blob/bb2fc63349bf949f6f6047ff447a0efb16983c0a/nlpaug/augmenter/sentence/sentence_augmenter.py#L18-L22

This PR would make it so that anything that list comprehension can be used on (i.e. Iterables) can be cleaned, and resolves the previous issue. 