### PR TITLE
Fix util script for downloading Google Drive files and Word2Vec weights

### DIFF
--- a/nlpaug/util/file/download.py
+++ b/nlpaug/util/file/download.py
@@ -1,4 +1,12 @@
-import os, urllib, zipfile, tarfile, requests
+import gzip
+import os
+import shutil
+import tarfile
+import urllib
+import zipfile
+
+import gdown
+import requests
 
 
 class DownloadUtil:
@@ -9,16 +17,20 @@ class DownloadUtil:
     """
 
     @staticmethod
-    def download_word2vec(dest_dir):
+    def download_word2vec(dest_dir: str = "."):
         """
         :param str dest_dir: Directory of saving file
+        :return: Word2Vec C binary file named 'GoogleNews-vectors-negative300.bin'
 
         >>> DownloadUtil.download_word2vec('.')
 
         """
-        DownloadUtil.download_from_google_drive(
-            _id='0B7XkCwpI5KDYNlNUTTlSS21pQmM', dest_dir=dest_dir, dest_file='GoogleNews-vectors-negative300.zip'
+        file_path = DownloadUtil.download_from_google_drive(
+            url="https://drive.google.com/uc?export=download&id=0B7XkCwpI5KDYNlNUTTlSS21pQmM",
+            dest_dir=dest_dir,
+            dest_file="GoogleNews-vectors-negative300.bin.gz",
         )
+        DownloadUtil.unzip(file_path, dest_dir=dest_dir)
 
     @staticmethod
     def download_glove(model_name, dest_dir):
@@ -31,18 +43,25 @@ class DownloadUtil:
 
         """
 
-        url = ''
-        if model_name == 'glove.6B':
-            url = 'http://nlp.stanford.edu/data/glove.6B.zip'
-        elif model_name == 'glove.42B.300d':
-            url = 'http://nlp.stanford.edu/data/glove.42B.300d.zip'
-        elif model_name == 'glove.840B.300d':
-            url = 'http://nlp.stanford.edu/data/glove.840B.300d.zip'
-        elif model_name == 'glove.twitter.27B':
-            url = 'http://nlp.stanford.edu/data/glove.twitter.27B.zip',
+        url = ""
+        if model_name == "glove.6B":
+            url = "http://nlp.stanford.edu/data/glove.6B.zip"
+        elif model_name == "glove.42B.300d":
+            url = "http://nlp.stanford.edu/data/glove.42B.300d.zip"
+        elif model_name == "glove.840B.300d":
+            url = "http://nlp.stanford.edu/data/glove.840B.300d.zip"
+        elif model_name == "glove.twitter.27B":
+            url = ("http://nlp.stanford.edu/data/glove.twitter.27B.zip",)
         else:
-            possible_values = ['glove.6B', 'glove.42B.300d', 'glove.840B.300d', 'glove.twitter.27B']
-            raise ValueError('Unknown model_name. Possible values are {}'.format(possible_values))
+            possible_values = [
+                "glove.6B",
+                "glove.42B.300d",
+                "glove.840B.300d",
+                "glove.twitter.27B",
+            ]
+            raise ValueError(
+                "Unknown model_name. Possible values are {}".format(possible_values)
+            )
 
         file_path = DownloadUtil.download(url, dest_dir=dest_dir)
         DownloadUtil.unzip(file_path)
@@ -58,25 +77,27 @@ class DownloadUtil:
 
         """
 
-        url = ''
-        if model_name == 'wiki-news-300d-1M':
-            url = 'https://dl.fbaipublicfiles.com/fasttext/vectors-english/wiki-news-300d-1M.vec.zip'
-        # elif model_name == 'wiki-news-300d-1M-subword':
-        #     url = 'https://dl.fbaipublicfiles.com/fasttext/vectors-english/wiki-news-300d-1M-subword.vec.zip'
-        elif model_name == 'crawl-300d-2M':
-            url = 'https://dl.fbaipublicfiles.com/fasttext/vectors-english/crawl-300d-2M.vec.zip'
-        # elif model_name == 'crawl-300d-2M-subword':
-        #     url = 'https://dl.fbaipublicfiles.com/fasttext/vectors-english/crawl-300d-2M-subword.zip'
+        url = ""
+        if model_name == "wiki-news-300d-1M":
+            url = "https://dl.fbaipublicfiles.com/fasttext/vectors-english/wiki-news-300d-1M.vec.zip"
+        elif model_name == "wiki-news-300d-1M-subword":
+            url = "https://dl.fbaipublicfiles.com/fasttext/vectors-english/wiki-news-300d-1M-subword.vec.zip"
+        elif model_name == "crawl-300d-2M":
+            url = "https://dl.fbaipublicfiles.com/fasttext/vectors-english/crawl-300d-2M.vec.zip"
+        elif model_name == "crawl-300d-2M-subword":
+            url = "https://dl.fbaipublicfiles.com/fasttext/vectors-english/crawl-300d-2M-subword.zip"
         else:
-            possible_values = ['wiki-news-300d-1M', 'crawl-300d-2M']
-            raise ValueError('Unknown model_name. Possible values are {}'.format(possible_values))
+            possible_values = ["wiki-news-300d-1M", "crawl-300d-2M"]
+            raise ValueError(
+                "Unknown model_name. Possible values are {}".format(possible_values)
+            )
 
         file_path = DownloadUtil.download(url, dest_dir=dest_dir)
         DownloadUtil.unzip(file_path)
 
     @staticmethod
     def download_back_translation(dest_dir):
-        url = 'https://storage.googleapis.com/uda_model/text/back_trans_checkpoints.zip'
+        url = "https://storage.googleapis.com/uda_model/text/back_trans_checkpoints.zip"
         file_path = DownloadUtil.download(url, dest_dir=dest_dir)
         DownloadUtil.unzip(file_path)
 
@@ -91,7 +112,7 @@ class DownloadUtil:
         if not os.path.exists(dest_dir + dest_file):
             req = urllib.request.Request(src)
             file = urllib.request.urlopen(req)
-            with open(os.path.join(dest_dir, dest_file), 'wb') as output:
+            with open(os.path.join(dest_dir, dest_file), "wb") as output:
                 output.write(file.read())
         return os.path.join(dest_dir, dest_file)
 
@@ -107,7 +128,7 @@ class DownloadUtil:
         if dest_dir is None:
             dest_dir = os.path.dirname(file_path)
 
-        if file_path.endswith('.zip'):
+        if file_path.endswith(".zip"):
             with zipfile.ZipFile(file_path, "r") as zip_ref:
                 zip_ref.extractall(dest_dir)
         elif file_path.endswith("tar.gz") or file_path.endswith("tgz"):
@@ -118,33 +139,15 @@ class DownloadUtil:
             tar = tarfile.open(file_path, "r:")
             tar.extractall(dest_dir)
             tar.close()
+        elif file_path.endswith("bin.gz"):
+            with gzip.open(file_path, "rb") as f_in:
+                with open(file_path.replace(".gz", ""), "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
 
     @staticmethod
-    def download_from_google_drive(_id, dest_dir, dest_file):
-        url = "https://docs.google.com/uc?export=download"
-
-        def get_confirm_token(response):
-            for key, value in response.cookies.items():
-                if key.startswith('download_warning'):
-                    return value
-
-            return None
-
-        def save_response_content(response, destination):
-            CHUNK_SIZE = 32768
-
-            with open(destination, "wb") as f:
-                for chunk in response.iter_content(CHUNK_SIZE):
-                    if chunk:  # filter out keep-alive new chunks
-                        f.write(chunk)
-
-        session = requests.Session()
-
-        response = session.get(url, params={'id': _id}, stream=True)
-        token = get_confirm_token(response)
-
-        if token:
-            params = {'id': _id, 'confirm': token}
-            response = session.get(url, params=params, stream=True)
-
-        save_response_content(response, os.path.join(dest_dir, dest_file))
+    def download_from_google_drive(
+        url: str = "https://drive.google.com/uc?export=download&id=0B7XkCwpI5KDYNlNUTTlSS21pQmM",
+        dest_dir: str = ".",
+        dest_file: str = "/tmp/nlpaug_model.zip",
+    ) -> str:
+        return gdown.download(url, output=f"{dest_dir}/{dest_file}", quiet=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.16.2
 pandas>=1.2.0
 requests>=2.22.0
+gdown>=4.0.0


### PR DESCRIPTION
The download script for downloading Google Drive documents seems to no longer work for Google Drive.
Updated the script to use `gdown` and now works to download the word2vec weights

@makcedward 
Fixes issue #301 