### PR TITLE
Truncate to model max length in back translation

### DIFF
--- a/nlpaug/model/lang_models/machine_translation_transformers.py
+++ b/nlpaug/model/lang_models/machine_translation_transformers.py
@@ -44,7 +44,7 @@ class MtTransformers(LanguageModels):
     def translate_one_step_batched(
             self, data, tokenizer, model
     ):
-        tokenized_texts = tokenizer(data, padding=True, return_tensors='pt')
+        tokenized_texts = tokenizer(data, padding=True, truncation=True, return_tensors='pt')
         tokenized_dataset = t_data.TensorDataset(*(tokenized_texts.values()))
         tokenized_dataloader = t_data.DataLoader(
             tokenized_dataset,


### PR DESCRIPTION
Currently, there is no truncation on the input text in the back translation augmenter. This leads to hard-to-parse errors when input text longer than the models max input length is provided (and the model is running on the GPU). This PR fixes that by providing the argument `truncation=True` to the HF tokenizer, which truncates any text longer than the models max input size.

Closes #297