### PR TITLE
Add check to fix bug caused by short token lists in word augmenter

### DIFF
--- a/nlpaug/augmenter/word/word_augmenter.py
+++ b/nlpaug/augmenter/word/word_augmenter.py
@@ -98,13 +98,13 @@ class WordAugmenter(Augmenter):
 
     def _get_aug_range_idxes(self, tokens):
         aug_cnt = self.generate_aug_cnt(len(tokens))
-        if aug_cnt == 0 or len(tokens) == 0:
+        if (aug_cnt == 0) or (aug_cnt >= len(tokens)):
             return []
         direction = self.sample([-1, 1], 1)[0]
 
         if direction > 0:
             # right
-            word_idxes = [i for i, _ in enumerate(tokens[:-aug_cnt+1])]
+            word_idxes = [i for i, _ in enumerate(tokens[:-aug_cnt])]
         else:
             # left
             word_idxes = [i for i, _ in enumerate(tokens[aug_cnt-1:])]


### PR DESCRIPTION


_get_aug_range_idxes fails if length of tokens is less than or equal to aug_cnt, which primarily shows up in cases where sequences are too short. fixing this by adding a check