### PR TITLE
Remove invalid num_beam argument from textual_augmenter

### DIFF
--- a/example/textual_augmenter.ipynb
+++ b/example/textual_augmenter.ipynb
@@ -1162,7 +1162,7 @@
     "until the late 1980s when the first statistical machine translation systems were developed.\n",
     "\"\"\"\n",
     "\n",
-    "aug = nas.AbstSummAug(model_path='t5-base', num_beam=3)\n",
+    "aug = nas.AbstSummAug(model_path='t5-base')\n",
     "augmented_text = aug.augment(article)\n",
     "print(\"Original:\")\n",
     "print(article)\n",


### PR DESCRIPTION
Remove invalid `num_beam` argument from the `textual_augmenter.ipynb` example.