### PR TITLE
Fix LookupError from nltk.pos_tag in Wordnet model

### DIFF
--- a/nlpaug/model/word_dict/wordnet.py
+++ b/nlpaug/model/word_dict/wordnet.py
@@ -55,9 +55,14 @@ class WordNet(WordDictionary):
     @classmethod
     def pos_tag(cls, tokens):
         try:
-            results = nltk.pos_tag(tokens)
+            from nltk.tag import PerceptronTagger
+            return PerceptronTagger().tag(tokens)
         except LookupError:
+            import nltk
             nltk.download('averaged_perceptron_tagger')
-            results = nltk.pos_tag(tokens)
+            return PerceptronTagger().tag(tokens)
 
-        return results
+    
+    
+
+    


### PR DESCRIPTION
This fixes an issue where `nltk.pos_tag()` internally triggers a `LookupError` due to attempting to load the non-existent resource `averaged_perceptron_tagger_eng`. The fix avoids this by directly using `PerceptronTagger()` without the `lang='eng'` parameter, and re-instantiates it after downloading the tagger model if necessary. Verified in Google Colab, this resolves the common synonym augmentation crash encountered by many users when using `nlpaug` with WordNet-based augmenters. The change is backward-compatible with existing usage.

