### PR TITLE
Fix SyntaxWarning: use raw strings for regex in context_word_embs.py

### DIFF
--- a/nlpaug/augmenter/word/context_word_embs.py
+++ b/nlpaug/augmenter/word/context_word_embs.py
@@ -120,8 +120,8 @@ class ContextualWordEmbsAug(WordAugmenter):
 
     def _build_stop_words(self, stopwords):
         if stopwords:
-            prefix_reg = '(?<=\s|\W)'
-            suffix_reg = '(?=\s|\W)'
+            prefix_reg = r'(?<=\s|\W)'
+            suffix_reg = r'(?=\s|\W)'
             stopword_reg = '('+')|('.join([prefix_reg + re.escape(s) + suffix_reg for s in stopwords])+')'
             self.stopword_reg = re.compile(stopword_reg)
 


### PR DESCRIPTION
### Summary

This PR fixes a `SyntaxWarning` in `context_word_embs.py` raised by Python 3.12+ due to unescaped regex sequences like `\s` and `\W`.

### Changes
- Use raw strings for regex: `r'(?<=\s|\W)'` and `r'(?=\s|\W)'`

### Why?
- Fixes compatibility issues with Python 3.12+.
- Resolves warning shown in issue.

### Related
Fixes #350