### PR TITLE
docs: fix changelog parameters typo

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -67,7 +67,7 @@ NLPAUG Change Log
 *   Refactoring audio and spectrogram augmenters
 *   Added LoudnessAug into spectrogram augmenters
 *   Support single forward data input for deep learning models (i.e. ContextualWordEmbsAug, BackTranslationAug, ContextualWordEmbsForSentenceAug, AbstSummAug). [#146](https://github.com/makcedward/nlpaug/issues/146)
-*   Fix missing re-assing model paramters (e.g. device) for deep learning model
+*   Fix missing re-assing model parameters (e.g. device) for deep learning model
 *   BackTranslation supports to load model from local [#149](https://github.com/makcedward/nlpaug/issues/149)
 *   Fix device parameter bug [#150](https://github.com/makcedward/nlpaug/issues/150)
 *   Deprecated include_detail feature


### PR DESCRIPTION
## Summary
- Fix a `paramters` typo in the changelog entry about model parameters.

## Validation
- `git diff --check`

Confidence: 80/100 (docs/typo)